### PR TITLE
discord 모듈은 discord.py 미러 모듈입니다.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 aiohttp
-discord
+discord.py
 cairosvg


### PR DESCRIPTION
discord 모듈은 discord.py 미러 모듈이며 공식 discord pypi에서도 discord.py를 대신 사용하는 것을 추천합니다. 이에 따라 requirements.txt를 변경했습니다.
![image](https://user-images.githubusercontent.com/74066467/124543459-40c7e180-de60-11eb-9175-6eea44de7718.png)