### PR TITLE
discord.py의 명시적 의존성 제거

### DIFF
--- a/koreanbots/abc.py
+++ b/koreanbots/abc.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
 
 
 class KoreanbotsABC(metaclass=abc.ABCMeta):
@@ -18,3 +18,39 @@ class KoreanbotsABC(metaclass=abc.ABCMeta):
     @abc.abstractproperty
     def data(self) -> Dict[str, Any]:
         return self.response_data.get("data", {})
+
+
+class DiscordABC(metaclass=abc.ABCMeta):
+    @abc.abstractmethod
+    async def close(self) -> None:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    async def wait_until_ready(self) -> None:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def is_closed(self) -> bool:
+        raise NotImplementedError
+
+    @abc.abstractproperty
+    def guilds(self) -> List["DiscordGuildABC"]:
+        raise NotImplementedError
+
+    @abc.abstractproperty
+    def user(self) -> Optional["DiscordUserABC"]:
+        raise NotImplementedError
+
+    @abc.abstractproperty
+    def shard_count(self) -> Optional[int]:
+        raise NotImplementedError
+
+
+class DiscordUserABC(metaclass=abc.ABCMeta):
+    @abc.abstractproperty
+    def id(self) -> int:
+        raise NotImplementedError
+
+
+class DiscordGuildABC(metaclass=abc.ABCMeta):
+    ...

--- a/koreanbots/abc.py
+++ b/koreanbots/abc.py
@@ -1,4 +1,4 @@
-from abc import abstractmethod, ABCMeta
+from abc import ABCMeta, abstractmethod
 from typing import Any, Dict, List, Optional
 
 

--- a/koreanbots/abc.py
+++ b/koreanbots/abc.py
@@ -1,56 +1,63 @@
-import abc
+from abc import abstractmethod, ABCMeta
 from typing import Any, Dict, List, Optional
 
 
-class KoreanbotsABC(metaclass=abc.ABCMeta):
-    @abc.abstractmethod
+class KoreanbotsABC(metaclass=ABCMeta):
+    @abstractmethod
     def __init__(self, **response_data: Any) -> None:
         self.response_data = response_data
 
-    @abc.abstractproperty
+    @property
+    @abstractmethod
     def code(self) -> int:
         return self.response_data.get("code", 0)
 
-    @abc.abstractproperty
+    @property
+    @abstractmethod
     def version(self) -> int:
         return self.response_data.get("version", 0)
 
-    @abc.abstractproperty
+    @property
+    @abstractmethod
     def data(self) -> Dict[str, Any]:
         return self.response_data.get("data", {})
 
 
-class DiscordABC(metaclass=abc.ABCMeta):
-    @abc.abstractmethod
+class DiscordABC(metaclass=ABCMeta):
+    @abstractmethod
     async def close(self) -> None:
         raise NotImplementedError
 
-    @abc.abstractmethod
+    @abstractmethod
     async def wait_until_ready(self) -> None:
         raise NotImplementedError
 
-    @abc.abstractmethod
+    @abstractmethod
     def is_closed(self) -> bool:
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abstractmethod
     def guilds(self) -> List["DiscordGuildABC"]:
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abstractmethod
     def user(self) -> Optional["DiscordUserABC"]:
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abstractmethod
     def shard_count(self) -> Optional[int]:
         raise NotImplementedError
 
 
-class DiscordUserABC(metaclass=abc.ABCMeta):
-    @abc.abstractproperty
+class DiscordUserABC(metaclass=ABCMeta):
+    @property
+    @abstractmethod
     def id(self) -> int:
         raise NotImplementedError
 
 
-class DiscordGuildABC(metaclass=abc.ABCMeta):
+class DiscordGuildABC(metaclass=ABCMeta):
     ...

--- a/koreanbots/client.py
+++ b/koreanbots/client.py
@@ -4,7 +4,7 @@ from logging import getLogger
 from typing import Optional
 
 import aiohttp
-from discord import Client
+from .abc import DiscordABC
 
 from .decorator import strict_literal
 from .http import KoreanbotsRequester
@@ -21,7 +21,7 @@ class Koreanbots(KoreanbotsRequester):
     :param client:
         discord.Client의 클래스입니다. 만약 필요한 경우 이 인수를 지정하세요.
     :type client:
-        Optional[Client]
+        Optional[DiscordABC]
 
     :param api_key:
         API key를 지정합니다. 만약 필요한 경우 이 키를 지정하세요.
@@ -46,7 +46,7 @@ class Koreanbots(KoreanbotsRequester):
 
     def __init__(
         self,
-        client: Optional[Client] = None,
+        client: Optional[DiscordABC] = None,
         api_key: Optional[str] = None,
         session: Optional[aiohttp.ClientSession] = None,
         run_task: bool = False,

--- a/koreanbots/client.py
+++ b/koreanbots/client.py
@@ -85,6 +85,9 @@ class Koreanbots(KoreanbotsRequester):
         await self.client.wait_until_ready()
 
         while not self.client.is_closed():
+            if not self.client.user:
+                continue
+
             kwargs = {"servers": len(self.client.guilds)}
             if self.include_shard_count:
                 if self.client.shard_count:

--- a/koreanbots/client.py
+++ b/koreanbots/client.py
@@ -4,8 +4,8 @@ from logging import getLogger
 from typing import Optional
 
 import aiohttp
-from .abc import DiscordABC
 
+from .abc import DiscordABC
 from .decorator import strict_literal
 from .http import KoreanbotsRequester
 from .model import KoreanbotsBot, KoreanbotsUser, KoreanbotsVote

--- a/koreanbots/client.py
+++ b/koreanbots/client.py
@@ -1,10 +1,10 @@
 import asyncio
 from asyncio.events import get_event_loop
 from logging import getLogger
-from typing import Optional, Union
+from typing import Optional
 
 import aiohttp
-from discord import Client, Member, User
+from discord import Client
 
 from .decorator import strict_literal
 from .http import KoreanbotsRequester

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 aiohttp
-discord.py

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,7 @@
-from koreanbots.model import KoreanbotsBot, KoreanbotsUser
-from koreanbots.client import Koreanbots
 import pytest
+
+from koreanbots.client import Koreanbots
+from koreanbots.model import KoreanbotsBot, KoreanbotsUser
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
discord.py의 개발 중단을 고려, 포크 버전 사용이 가능하도록 명시적 의존을 제거했습니다.