### PR TITLE
fix: guild update not running on on_ready registered

### DIFF
--- a/koreanbots/integrations/discord.py
+++ b/koreanbots/integrations/discord.py
@@ -61,6 +61,7 @@ class DiscordpyKoreanbots(Koreanbots):
 
             def event(coro: CoroT, /) -> CoroT:
                 if coro.__name__ == "on_ready":
+
                     async def on_ready() -> None:
                         self.run_post_guild_count_task()
                         await coro()

--- a/koreanbots/integrations/discord.py
+++ b/koreanbots/integrations/discord.py
@@ -1,6 +1,6 @@
 from asyncio.tasks import Task, sleep
 from logging import getLogger
-from typing import TYPE_CHECKING, Optional, Union, TypeVar, Callable, Coroutine, Any
+from typing import TYPE_CHECKING, Any, Callable, Coroutine, Optional, TypeVar, Union
 
 from aiohttp import ClientSession
 
@@ -11,9 +11,9 @@ if TYPE_CHECKING:
     from discord import Client as DiscordpyClient
     from disnake.client import Client as DisnakeClient
 
-T = TypeVar('T')
+T = TypeVar("T")
 Coro = Coroutine[Any, Any, T]
-CoroT = TypeVar('CoroT', bound=Callable[..., Coro[Any]])
+CoroT = TypeVar("CoroT", bound=Callable[..., Coro[Any]])
 
 log = getLogger(__name__)
 
@@ -60,7 +60,10 @@ class DiscordpyKoreanbots(Koreanbots):
                     self.run_post_guild_count_task()
 
             def event(coro: CoroT, /) -> CoroT:
-                if coro.__name__ == "on_ready" and (orig := getattr(client, "on_ready", None)):
+                if coro.__name__ == "on_ready" and (
+                    orig := getattr(client, "on_ready", None)
+                ):
+
                     async def on_ready() -> None:
                         await orig()
                         await coro()

--- a/koreanbots/integrations/discord.py
+++ b/koreanbots/integrations/discord.py
@@ -1,6 +1,15 @@
 from asyncio.tasks import Task, sleep
 from logging import getLogger
-from typing import TYPE_CHECKING, Any, Callable, Coroutine, Optional, TypeVar, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Coroutine,
+    Optional,
+    TypeVar,
+    Union,
+    cast,
+)
 
 from aiohttp import ClientSession
 
@@ -66,9 +75,9 @@ class DiscordpyKoreanbots(Koreanbots):
                         self.run_post_guild_count_task()
                         await coro()
 
-                    return client_event(on_ready)
+                    return cast(CoroT, client_event(on_ready))
 
-                return client_event(coro)
+                return cast(CoroT, client_event(coro))
 
             client.event(on_ready)
             setattr(client, "event", event)

--- a/koreanbots/integrations/discord.py
+++ b/koreanbots/integrations/discord.py
@@ -60,12 +60,9 @@ class DiscordpyKoreanbots(Koreanbots):
                     self.run_post_guild_count_task()
 
             def event(coro: CoroT, /) -> CoroT:
-                if coro.__name__ == "on_ready" and (
-                    orig := getattr(client, "on_ready", None)
-                ):
-
+                if coro.__name__ == "on_ready":
                     async def on_ready() -> None:
-                        await orig()
+                        self.run_post_guild_count_task()
                         await coro()
 
                     return client_event(on_ready)


### PR DESCRIPTION
- DiscordpyKoreanbots에서 run_task=True일 때 on_ready 이벤트가 새로 등록되는 경우 서버수 업데이트가 이루어지지 않는 문제를 해결했습니다.